### PR TITLE
Update the list of packages to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
     - GAPROOT=gaproot
     - COVDIR=coverage
-    - GAP_PKGS_TO_BUILD="io 4ti2Interface NormalizInterface"
+    - GAP_PKGS_TO_BUILD="io profiling NormalizInterface"
 
 addons:
   apt_packages:


### PR DESCRIPTION
4ti2interface does not require building. OTOH, profiling must be built for code coverage.