### PR TITLE
PackageInfo.g: add License field; clarify license is GPL 2 or later; fix a typo

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -104,7 +104,7 @@ AutoDoc := rec(
                 ),
         Acknowledgements := Concatenation(
                     "The authors are grateful to Sebastian Gutsche, Christof Söger and Max Horn for endowing GAP\n",
-                    "with a 4ti2-Interface and a normlaiz-Interface.\n",
+                    "with a 4ti2-Interface and a normaliz-Interface.\n",
                     "We also would like to thank Gutsche and Söger for many very helpful discussions.\n",
                     "We also want to give credits to the developers of the softwares 4ti2 and normaliz.\n",
                     "Thanks go to David Avis for writing lrslib and answering our questions about it.\n",

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -13,7 +13,8 @@ PackageName    := "HeLP",
 Subtitle       := Concatenation( [
                   "Hertweck-Luthar-Passi method." ] ),
 Version        := "3.4",
-Date           := "20/11/2018",
+Date           := "20/11/2018", # dd/mm/yyyy format
+License        := "GPL-2.0-or-later",
 
 SourceRepository := rec(
     Type := "git",
@@ -100,7 +101,7 @@ AutoDoc := rec(
         Copyright := Concatenation(
                     "&copyright; 2017 by Andreas Bächle and Leo Margolis<P/>\n\n",
                     "This package is free software and may be distributed under the terms and conditions of the\n",
-                    "GNU Public License Version 2.\n"
+                    "GNU Public License Version 2, or (at your option) any later version.\n"
                 ),
         Acknowledgements := Concatenation(
                     "The authors are grateful to Sebastian Gutsche, Christof Söger and Max Horn for endowing GAP\n",


### PR DESCRIPTION
PackageInfo.g: add License field

.. and also clarify that the package is GPL 2 *or later*. Otherwise, it
becomes impossible (at least from a legal point of view) to use this package
together with packages that are licensed under GPL 3 or later.
