### PR TITLE
Import the 3.5 release into git

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Changes v3.4 -> v3.5
+
+* Package now dependend on AtlasRep to avoid undeclared variable
+
 Changes v3.3 -> v3.4
 
 * Package migrated to GitHub

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -12,8 +12,8 @@ SetPackageInfo( rec(
 PackageName    := "HeLP",
 Subtitle       := Concatenation( [
                   "Hertweck-Luthar-Passi method." ] ),
-Version        := "3.4",
-Date           := "20/11/2018", # dd/mm/yyyy format
+Version        := "3.5",
+Date           := "17/12/2019", # dd/mm/yyyy format
 License        := "GPL-2.0-or-later",
 
 SourceRepository := rec(
@@ -82,7 +82,13 @@ AbstractHTML := "<span class=\"pkgname\">HeLP</span> is a package to compute con
                   
 Dependencies := rec(
   GAP                    := ">=4.8.2",
-  NeededOtherPackages    := [ ["io", ">=4.2" ], ["4ti2Interface", ">= 2015.04.29"], ["CTblLib", ">= 1.2.2"], ["NormalizInterface", ">= 0.9.6"] ],
+  NeededOtherPackages    := [
+    ["io", ">=4.2" ],
+    ["4ti2Interface", ">= 2015.04.29"],
+    ["CTblLib", ">= 1.2.2"],
+    ["atlasrep", ">= 1.5"],
+    ["NormalizInterface", ">= 0.9.6"],
+  ],
   SuggestedOtherPackages := [ ],
   ExternalConditions     := [[ "zsolve", "http://www.4ti2.de" ] ]
 ),

--- a/doc/HeLP.bib
+++ b/doc/HeLP.bib
@@ -13,51 +13,100 @@
 
 @article {BaCa,
     AUTHOR = {B\"achle, A. and Caicedo, M.},
-     TITLE = {On the Prime Graph Question for Almost Simple Groups with an Alternatin Socle},
-   JOURNAL = {Submitted, \href{http://arxiv.org/abs/1510.04598}{\nolinkurl{arXiv:1510.04598 [math.RT]}}},
-      YEAR = {2015},
-      NOTE = {11 pages}
+     TITLE = {On the prime graph question for almost simple groups with an
+              alternating socle},
+   JOURNAL = {Internat. J. Algebra Comput.},
+    VOLUME = {27},
+      YEAR = {2017},
+    NUMBER = {3},
+     PAGES = {333--347}
 }
 
 @article {BaHeKoMaSi,
-    AUTHOR = {B\"achle, A. and Herman, A. and Konovalov, A. and Margolis, L. and Singh, G.},
-     TITLE = {The status of the Zassenhaus conjecture for small groups},
-   JOURNAL = {Submitted},
-      YEAR = {2016},
-      NOTE = {10 pages, \href{https://arxiv.org/abs/1609.00042}{\nolinkurl{arXiv:1609.00042 [math.RA]}}}
+    AUTHOR = {B\"{a}chle, Andreas and Herman, Allen and Konovalov, Alexander and
+              Margolis, Leo and Singh, Gurmail},
+     TITLE = {The status of the {Z}assenhaus conjecture for small groups},
+   JOURNAL = {Exp. Math.},
+  FJOURNAL = {Experimental Mathematics},
+    VOLUME = {27},
+      YEAR = {2018},
+    NUMBER = {4},
+     PAGES = {431--436}
+}
+
+@article{BaechleKimmerleSerrano18,
+    AUTHOR = {B\"achle, A. and Kimmerle, W. and Serrano, M.},
+     TITLE = {On the first {Z}assenhaus conjecture and direct products},
+   JOURNAL = {Can. J. Math. (to appear)},
+      YEAR = {2018},
+     PAGES = {1--17}
 }
 
 @article {BaMaM10,
     AUTHOR = {B\"achle, A. and Margolis, L.},
-     TITLE = {Rational conjugacy of torsion units in integral group rings of non-solvable groups},
-   JOURNAL = {Accepted in Proc. Edinb. Math. Soc., \href{http://arxiv.org/abs/1305.7419}{\nolinkurl{arXiv:1305.7419 [math.RT]}}},
-      YEAR = {2014},
-      NOTE = {22 pages}
+     TITLE = {Rational conjugacy of torsion units in integral group rings of
+              non-solvable groups},
+   JOURNAL = {Proc. Edinb. Math. Soc. (2)},
+    VOLUME = {60},
+      YEAR = {2017},
+    NUMBER = {4},
+     PAGES = {813--830}
 }
 
 @article {BaMaHeLPArticle,
-    AUTHOR = {B{\"a}chle, A. and Margolis, L.},
-     TITLE = {{HeLP} -- {A} \textsf{GAP}-package for torsion units in integral group rings},
-   JOURNAL = {Submitted},
-      YEAR = {2015},
-      NOTE = {7 pages, \href{http://arxiv.org/abs/1507.08174}{\nolinkurl{arXiv:1507.08174 [math.RT]}}},
+    AUTHOR = {B\"achle, A. and Margolis, L.},
+     TITLE = {He{LP}: a {GAP} package for torsion units in integral group
+              rings},
+   JOURNAL = {J. Softw. Algebra Geom.},
+  FJOURNAL = {Journal of Software for Algebra and Geometry},
+    VOLUME = {8},
+      YEAR = {2018},
+     PAGES = {1--9}
 }
 
 @article {BaMa4prI,
     AUTHOR = {B\"achle, A. and Margolis, L.},
-     TITLE = {On the {P}rime {G}raph {Q}uestion for {I}ntegral {G}roup {R}ings of 4-primary groups {I}},
-   JOURNAL = {Submitted},
-      YEAR = {2016},
-      NOTE = {33 pages, \href{http://arxiv.org/abs/1601.05689}{\nolinkurl{arXiv:1601.05689 [math.RT]}}}
+     TITLE = {On the prime graph question for integral group rings of
+              4-primary groups {I}},
+   JOURNAL = {Internat. J. Algebra Comput.},
+    VOLUME = {27},
+      YEAR = {2017},
+    NUMBER = {6},
+     PAGES = {731--767}
 }
 
 @article {BaMa4prII,
-    AUTHOR = {B\"achle, A. and Margolis, L.},
-     TITLE = {On the {P}rime {G}raph {Q}uestion for {I}ntegral {G}roup {R}ings of 4-primary groups {II}},
-   JOURNAL = {Submitted},
-      YEAR = {2016},
-      NOTE = {17 pages, \href{https://arxiv.org/abs/1606.01506}{\nolinkurl{arXiv:1606.01506 [math.RT]}}}
+AUTHOR = {B\"{a}chle, Andreas and Margolis, Leo},
+     TITLE = {On the prime graph question for integral group rings of
+              4-primary groups {II}},
+   JOURNAL = {Algebr. Represent. Theory},
+  FJOURNAL = {Algebras and Representation Theory},
+    VOLUME = {22},
+      YEAR = {2019},
+    NUMBER = {2},
+     PAGES = {437--457}
 }
+
+@article {BaMaAn,
+    AUTHOR = {B\"{a}chle, Andreas and Margolis, Leo},
+     TITLE = {An application of blocks to torsion units in group rings},
+   JOURNAL = {Proc. Amer. Math. Soc.},
+  FJOURNAL = {Proceedings of the American Mathematical Society},
+    VOLUME = {147},
+      YEAR = {2019},
+    NUMBER = {10},
+     PAGES = {4221--4231}
+}
+
+@article {BovdiHertweck,
+    AUTHOR = {Bovdi, V. A. and Hertweck, M.},
+     TITLE = {Zassenhaus conjecture for central extensions of {$S_5$}},
+   JOURNAL = {J. Group Theory},
+    VOLUME = {11},
+      YEAR = {2008},
+    NUMBER = {1},
+     PAGES = {63--74}
+} 
 
 @article {BJK,
     AUTHOR = {Bovdi, V. A. and Jespers, E. and Konovalov, A. B.},
@@ -71,16 +120,6 @@
      PAGES = {593--615},
 }
 
-@article {BovdiHertweck,
-    AUTHOR = {Bovdi, V. A. and Hertweck, M.},
-     TITLE = {Zassenhaus conjecture for central extensions of {$S_5$}},
-   JOURNAL = {J. Group Theory},
-  FJOURNAL = {Journal of Group Theory},
-    VOLUME = {11},
-      YEAR = {2008},
-    NUMBER = {1},
-     PAGES = {63--74}
-}     
 
 @incollection {KonovalovM11,
     AUTHOR = {Bovdi, V. A. and Konovalov, A. B.},
@@ -92,6 +131,89 @@
  PUBLISHER = {Cambridge Univ. Press, Cambridge},
       YEAR = {2007}
 }
+
+@article {BovdiKonovalovM12,
+    AUTHOR = {Bovdi, V. A. and Konovalov, A. B. and Siciliano, S.},
+     TITLE = {Integral group ring of the {M}athieu simple group {$M_{12}$}},
+   JOURNAL = {Rend. Circ. Mat. Palermo (2)},
+  FJOURNAL = {Rendiconti del Circolo Matematico di Palermo. Serie II},
+    VOLUME = {56},
+      YEAR = {2007},
+    NUMBER = {1},
+     PAGES = {125--136}
+}
+		
+@article {BovdiKonovalovSuz,
+    AUTHOR = {Bovdi, V. A. and Konovalov, A. B. and Marcos,
+              E. d. N.},
+     TITLE = {Integral group ring of the {S}uzuki sporadic simple group},
+   JOURNAL = {Publ. Math. Debrecen},
+  FJOURNAL = {Publicationes Mathematicae Debrecen},
+    VOLUME = {72},
+      YEAR = {2008},
+    NUMBER = {3-4},
+     PAGES = {487--503}
+}
+
+@article {BovdiKonovalovM23,
+    AUTHOR = {Bovdi, V. A. and Konovalov, A. B.},
+     TITLE = {Integral group ring of the {M}athieu simple group {$M_{23}$}},
+   JOURNAL = {Comm. Algebra},
+  FJOURNAL = {Communications in Algebra},
+    VOLUME = {36},
+      YEAR = {2008},
+    NUMBER = {7},
+     PAGES = {2670--2680}
+}
+
+@article {BovdiKonovalovHe,
+    AUTHOR = {Bovdi, V. A. and Grishkov, A. N. and Konovalov, A. B.},
+     TITLE = {Kimmerle conjecture for the {H}eld and {O}'{N}an sporadic
+              simple groups},
+   JOURNAL = {Sci. Math. Jpn.},
+  FJOURNAL = {Scientiae Mathematicae Japonicae},
+    VOLUME = {69},
+      YEAR = {2009},
+    NUMBER = {3},
+     PAGES = {353--361}
+}
+
+@article {BovdiKonovalovRu,
+    AUTHOR = {Bovdi, V. A. and Konovalov, A. B.},
+     TITLE = {Integral group ring of {R}udvalis simple group},
+   JOURNAL = {Ukra\"\i n. Mat. Zh.},
+  FJOURNAL = {Nats\=\i onal\cprime na Akadem\=\i ya Nauk Ukra\"\i ni. \=Institut Matematiki.
+              Ukra\"\i ns\cprime ki\u\i  Matematichni\u\i  Zhurnal},
+    VOLUME = {61},
+      YEAR = {2009},
+    NUMBER = {1},
+     PAGES = {3--13}
+}
+
+
+@article {BovdiKonovalovM24,
+    AUTHOR = {Bovdi, V. A. and Konovalov, A. B.},
+     TITLE = {Integral group ring of the {M}athieu simple group {$M_{24}$}},
+   JOURNAL = {J. Algebra Appl.},
+  FJOURNAL = {Journal of Algebra and its Applications},
+    VOLUME = {11},
+      YEAR = {2012},
+    NUMBER = {1},
+     PAGES = {1250016, 10}
+}
+
+@article {BovdiKonovalovConway,
+    AUTHOR = {Bovdi, V. A. and Konovalov, A. B. and Linton, S.},
+     TITLE = {Torsion units in integral group rings of {C}onway simple
+              groups},
+   JOURNAL = {Internat. J. Algebra Comput.},
+  FJOURNAL = {International Journal of Algebra and Computation},
+    VOLUME = {21},
+      YEAR = {2011},
+    NUMBER = {4},
+     PAGES = {615--634}
+}
+
 
 @article {KonovalovM22,
     AUTHOR = {Bovdi, V. A. and Konovalov, A. B. and Linton, S.},
@@ -145,6 +267,14 @@ howpublished ={Available at \url{http://normaliz.uos.de}}
      PAGES = {65--78}
 }
 
+@article{CaMaBrauerTree,
+    AUTHOR = {Caicedo, M. and Margolis, L.},
+     TITLE = {Orders of units in integral group rings and blocks of defect 1},
+   JOURNAL = {preprint, arxiv.org/abs/arXiv:1906.03570},
+      YEAR = {2019},
+     PAGES = {26 pages}
+}
+
 @article {CohnLivingstone,
     AUTHOR = {Cohn, J. A. and Livingstone, D.},
      TITLE = {On the structure of group algebras. {I}},
@@ -166,6 +296,16 @@ howpublished ={Available at \url{http://normaliz.uos.de}}
  PUBLISHER = {John Wiley \& Sons, Inc., New York},
       YEAR = {1990},
      PAGES = {xxiv+819}
+}
+
+@article {EiMa18,
+    AUTHOR = {Eisele, Florian and Margolis, Leo},
+     TITLE = {A counterexample to the first {Z}assenhaus conjecture},
+   JOURNAL = {Adv. Math.},
+  FJOURNAL = {Advances in Mathematics},
+    VOLUME = {339},
+      YEAR = {2018},
+     PAGES = {599--641}
 }
 
 @article {Gildea,
@@ -301,6 +441,17 @@ year = {2015},
 pages = {331--347},
 }
 
+@article {LutharPassi1992,
+    AUTHOR = {Luthar, I. S. and Passi, I. B. S.},
+     TITLE = {Torsion units in matrix group rings},
+   JOURNAL = {Comm. Algebra},
+  FJOURNAL = {Communications in Algebra},
+    VOLUME = {20},
+      YEAR = {1992},
+    NUMBER = {4},
+     PAGES = {1223--1228}
+}
+
 @article {MRSW,
     AUTHOR = {Marciniak, Z. and Ritter, J. and Sehgal, S. and Weiss, A.},
      TITLE = {Torsion units in integral group rings of some metabelian
@@ -314,13 +465,71 @@ pages = {331--347},
        DOI = {10.1016/0022-314X(87)90037-0},
 }
 
-@article {FermatMersenne,
-    AUTHOR = {Margolis, L. and del R{\'{\i}}o, {\'A}. and Serrano, M.},
-     TITLE = {Zassenhaus Conjecture on torsion units holds for PSL(2,$p$) with $p$ a Fermat or Mersenne prime},
-   JOURNAL = {Submitted},
-     PAGES = {32 pages, \href{https://arxiv.org/abs/1608.05797}{\nolinkurl{arXiv:1608.05797 [math.RA]}}},
-      YEAR = {2016},
+@article {MargolisConway,
+    AUTHOR = {Margolis, Leo},
+     TITLE = {On the prime graph question for integral group rings of
+              {C}onway simple groups},
+   JOURNAL = {J. Symbolic Comput.},
+  FJOURNAL = {Journal of Symbolic Computation},
+    VOLUME = {95},
+      YEAR = {2019},
+     PAGES = {162--176}
 }
+
+@article {FermatMersenne,
+    AUTHOR = {Margolis, Leo and del R\'{\i}o, \'{A}ngel and Serrano, Mariano},
+     TITLE = {Zassenhaus conjecture on torsion units holds for {${\rm
+              PSL}(2,p)$} with {$p$} a {F}ermat or {M}ersenne prime},
+   JOURNAL = {J. Algebra},
+    VOLUME = {531},
+      YEAR = {2019},
+     PAGES = {320--335}
+}
+
+@article {MargolisdelRioCW1,
+    AUTHOR = {Margolis, L. and R{\'i}o, {\'A}. del},
+     TITLE = {Cliff--{W}eiss inequalities and the {Z}assenhaus {C}onjecture},
+   JOURNAL = {J. Algebra},
+  FJOURNAL = {Journal of Algebra},
+    VOLUME = {507},
+      YEAR = {2018},
+     PAGES = {292--319}
+}
+
+@article {MargolisdelRioCW3,
+    AUTHOR = {Margolis, Leo and del R\'{\i}o, \'{A}ngel},
+     TITLE = {Partial augmentations power property: a {Z}assenhaus
+              conjecture related problem},
+   JOURNAL = {J. Pure Appl. Algebra},
+  FJOURNAL = {Journal of Pure and Applied Algebra},
+    VOLUME = {223},
+      YEAR = {2019},
+    NUMBER = {9},
+     PAGES = {4089--4101}
+}
+
+@article{MadRSurvey,
+    AUTHOR = {Margolis, L. and del R\'{\i}o, \'{A}ngel},
+     TITLE = {Finite Subgroups of Group Rings: A survey},
+   JOURNAL = {preprint, arxiv.org/abs/arXiv:1809.00718},
+      YEAR = {2018},
+     PAGES = {23 pages}
+}
+
+
+
+@article {delRioSerrano19,
+    AUTHOR = {del R\'{\i}o, \'{A}ngel and Serrano, Mariano},
+     TITLE = {Zassenhaus conjecture on torsion units holds for {${\rm
+              SL}(2,p)$} and {${\rm SL}(2,p^2)$}},
+   JOURNAL = {J. Group Theory},
+  FJOURNAL = {Journal of Group Theory},
+    VOLUME = {22},
+      YEAR = {2019},
+    NUMBER = {5},
+     PAGES = {953--974}
+}
+		
 
 @article {SalimA7A8,
     AUTHOR = {Salim, M.},

--- a/examples/explanations.autodoc
+++ b/examples/explanations.autodoc
@@ -1,7 +1,0 @@
-@Chapter Extended examples
- We will give some more extended examples which are intended to 
- give the user an idea of the behaviour on different inputs,
- how to use the package more efficently, to use characters
- not available in libraries and how InfoLevels can be helpful.
-
-

--- a/examples/extended_examples.autodoc
+++ b/examples/extended_examples.autodoc
@@ -82,7 +82,7 @@ HeLP can detect that the character tables belong to the same group, if they are 
 are tables of the same group from the ATLAS and their InfoText begins with "origin: ATLAS of finite groups" (which is usually the case for ATLAS tables).
 If the program can verify that the character table which is used at the current call of a function belongs to the 
 same group as in the previous call of a function, the solutions stored in <K>HeLP_sol</K> are kept. 
-If the character table belongs to another group or it can not be made sure that the character tabel belongs to the same group,
+If the character table belongs to another group or it can not be made sure that the character table belongs to the same group,
 <K>HeLP_sol</K> is reset to the initial value <K>[ [ [1] ] ]</K> representing the trivial solution for units of order $1$.<P/>
 Not reseting <K>HeLP_sol</K> can also be achieved using <Ref Func='HeLP_ChangeCharKeepSols'/>. 
 However, caution should be exercised when using this command since it may manipulate <K>HeLP_sol</K> into something meaningless.

--- a/examples/introduction.autodoc
+++ b/examples/introduction.autodoc
@@ -18,7 +18,7 @@
  4ti2-Interface and normaliz-Interface written by S. Gutsche, C. Söger and M. Horn. 
  The 4ti2-Interface in turn uses the package IO, that needs a C-part to be compiled;
  see the readme-file or the documentation of the IO-package for details.
- The package also provides the possibility to use redund form the lrslib software <Cite Key="lrslib"/>,
+ The package also provides the possibility to use redund from the lrslib software <Cite Key="lrslib"/>,
  to remove redundant inequalities before solving the system, which might speed up the computations
  significantly when 4ti2 is used.  However, it is not a requirement to have lrslib installed.
  If the above mentioned preconditions are fulfilled, one just has to copy the HeLP-package in the GAP pkg-directory.

--- a/examples/purpose.autodoc
+++ b/examples/purpose.autodoc
@@ -12,15 +12,17 @@ For a more detailed exposition see <Cite Key="BaMaHeLPArticle"/>.
  element of the unit group of <M>\mathbb{Z}G</M> is called a torsion 
  element, if it has finite order. <P/>
 
- A long standing conjecture of H.J. Zassenhaus asserts that every
+ When the first versions of this package were published in 2015-2017 
+ a long standing conjecture of H.J. Zassenhaus asserted that every
  normalized torsion unit of <M>\mathbb{Z}G</M> is conjugate within 
  <M>\mathbb{Q}G</M> ("rationally conjugate") to an element of <M>G</M>, see
- <Cite Key="Zas"/> or <Cite Key="SehgalBook2"/>, Section 37.  This is the first 
+ <Cite Key="Zas"/> or <Cite Key="SehgalBook2"/>, Section 37.  This was the first 
  of his three famous conjectures about integral group rings and the
- only one which is nowadays still open, hence it is referred to as
- the Zassenhaus Conjecture (ZC).  This conjecture asserts that the
- torsion part of the units of <M>\mathbb{Z}G</M> is as far
- determined by <M>G</M> as possible. <P/>
+ only one which remained open at the time, hence it is referred to as
+ the Zassenhaus Conjecture (ZC).  
+
+ In October 2017 counterexamples to the Zassenhaus Conjecture were found by
+ F. Eisele and L. Margolis <Cite Key="EiMa18"/>.
 
  Considering the difficulty of the problem W. Kimmerle raised the
  question, whether the Prime Graph of the normalized units of 
@@ -128,8 +130,10 @@ There is also the concept of $(s,t)$-constant characters, being constant on both
 
 
 @Section Known results about the Zassenhaus Conjecture and the Prime Graph Question
+
+A survey on topics touched on by this package has been written in 2018 <Cite Key="MadRSurvey"/>. The counterexamples to the Zassenhaus Conjecture are of the form $(C_{pq} \times C_{pq}) \rtimes A$ where $p$ and $q$ are certain primes and $A$ is an abelian group with a specified action <Cite Key="EiMa18"/>. 
  
-At the moment as this documentation was written, to the best of our knowledge, the following results were available for the Zassenhaus Conjecture and the Prime Graph Question: <P/>
+In December 2019, to the best of our knowledge, the following positive results were available for the Zassenhaus Conjecture and the Prime Graph Question: <P/>
 For the Zassenhaus Conjecture only the following reduction is available: <P/><P/>
 **Theorem:** Assume the Zassenhaus Conjecture holds for a group $G$. Then (ZC) holds for $G \times C_2$ <Cite Key="HoefertKimmerle"/>, Corollary 3.3, and $G \times \Pi$, where $\Pi$ denotes a nilpotent group of order prime to the order of $G$ <Cite Key="HertweckEdinb"/>, Proposition 8.1.<P/>
 With this reductions in mind the Zassenhaus Conjecture is known for:
@@ -138,15 +142,21 @@ With this reductions in mind the Zassenhaus Conjecture is known for:
 * Groups containing a normal Sylow subgroup with abelian complement <Cite Key="HertweckColloq"/>,
 * Frobenius groups whose order is divisible by at most two different primes <Cite Key="JuriaansMilies"/>,
 * Groups $X \rtimes A$, where $X$ and $A$ are abelian and $A$ is of prime order $p$ such that $p$ is smaller then any prime divisor of the order of $X$ <Cite Key="MRSW"/>,
+* Groups with an abelian normal subgroup of index 2 <Cite Key="LutharPassi1992"/>,
+* Some more special classes of metabelian groups <Cite Key="MargolisdelRioCW1"/> and <Cite Key="MargolisdelRioCW3"/>,
+* Direct products of an abelian group and a Frobenius group with complement of odd order <Cite Key="BaechleKimmerleSerrano18"/>,
 * All groups of order up to 143 <Cite Key="BaHeKoMaSi"/>, 
-* The non-abelian simple groups $A_5$ <Cite Key="LP"/>, $A_6 \simeq PSL(2,9)$ <Cite Key="HerA6"/>, $PSL(2,7)$, $PSL(2,11)$, $PSL(2,13)$ <Cite Key="HertweckBrauer"/>, $PSL(2,8)$, $PSL(2,17)$ <Cite Key="KonovalovKimmiStAndrews"/> <Cite Key="Gildea"/>, $PSL(2,19)$, $PSL(2,23)$ <Cite Key="BaMaM10"/>, $PSL(2,25)$, $PSL(2,31)$, $PSL(2,32)$ <Cite Key="BaMa4prII"/> and some extensions of these groups. Also for all $PSL(2,p)$ where $p$ is a fermat or a Mersenne prime <Cite Key="FermatMersenne"/>.
+* The non-abelian simple groups $A_5$ <Cite Key="LP"/>, $A_6 \simeq PSL(2,9)$ <Cite Key="HerA6"/>, $PSL(2,7)$, $PSL(2,11)$, $PSL(2,13)$ <Cite Key="HertweckBrauer"/>, $PSL(2,8)$, $PSL(2,17)$ <Cite Key="KonovalovKimmiStAndrews"/> <Cite Key="Gildea"/>, $PSL(2,19)$, $PSL(2,23)$ <Cite Key="BaMaM10"/>, $PSL(2,25)$, $PSL(2,31)$, $PSL(2,32)$ <Cite Key="BaMa4prII"/> and some extensions of these groups. Also for all $PSL(2,p)$ where $p$ is a fermat or a Mersenne prime <Cite Key="FermatMersenne"/>,
+* For the following non-solvable and non-simple groups: $S_5$ <Cite Key="HertweckBrauer"/>, $\operatorname{GL}(2,5)$ and the covering group of $S_5$ <Cite Key="BovdiHertweck"/> and the groups $\operatorname{SL}(2,p)$ and $\operatorname{SL}(2,p^2)$ for any prime $p$ <Cite Key="delRioSerrano19"/>.
+
 
 For the Prime Graph Question the following strong reduction was obtained in <Cite Key="KonovalovKimmiStAndrews"/>: <P/>
 **Theorem:** Assume the Prime Graph Question holds for all almost simple images of a group $G$. Then (PQ) also holds for $G.$<P/>
 Here a group $G$ is called almost simple, if it is sandwiched between the inner automorphism group and the whole automorphism group of a non-abelian simple group $S$. I.e. $Inn(S) \leq G \leq Aut(S).$ Keeping this reduction in mind (PQ) is known for:
 * Solvable groups <Cite Key="KimmiPQ"/>,
+* Groups whose socle is isomorphic to an alternating group, <Cite Key="LP"/><Cite Key="HerA6"/><Cite Key="SalimA7A8"/><Cite Key="SalimA9A10"/><Cite Key="BaMaM10"/><Cite Key="BaCa"/><Cite Key="BaMaAn"/>,
 * Groups whose socle is isomorphic to a group $PSL(2,p)$ or $PSL(2,p^2)$, where $p$ denotes a prime, <Cite Key="HertweckBrauer"/>, <Cite Key="BaMa4prI"/>.
-* Half of the sporadic simple groups and their automorphism groups; for an overview see <Cite Key="KonovalovKimmiStAndrews"/>,
-* Groups whose socle is isomorphic to an alternating group of degree at most 17, <Cite Key="SalimA7A8"/> <Cite Key="SalimA9A10"/><Cite Key="BaCa"/>, 
-* Almost simple groups whose order is divisible by at most three different primes <Cite Key="KonovalovKimmiStAndrews"/> and <Cite Key="BaMaM10"/>. (This implies that it holds for all groups with an order divisible by at most three primes, using the reduction result above.)
-* Many almost simple groups whose order is divisible by four different primes <Cite Key="BaMa4prI"/><Cite Key="BaMa4prII"/>.
+* A group with sporadic simple socle which is not the O'Nan group or the Monster <Cite Key="KonovalovM11"/><Cite Key="KonovalovMcL"/><Cite Key="BovdiKonovalovM12"/><Cite Key="BovdiKonovalovConway"/><Cite Key="BovdiKonovalovSuz"/><Cite Key="BovdiKonovalovM23"/><Cite Key="BovdiKonovalovHe"/><Cite Key="BJK"/><Cite Key="BovdiKonovalovM24"/><Cite Key="BovdiKonovalovRu"/><Cite Key="KonovalovM22"/> <Cite Key="BKHS"/><Cite Key="KonovalovKimmiStAndrews"/><Cite Key="MargolisConway"/><Cite Key="BaMaAn"/><Cite Key="CaMaBrauerTree"/>,
+* Almost simple groups whose order is divisible by at most three different primes <Cite Key="KonovalovKimmiStAndrews"/> and <Cite Key="BaMaM10"/>. This implies that it holds for all groups with an order divisible by at most three primes, using the reduction result above.
+* Many almost simple groups whose order is divisible by four different primes <Cite Key="BaMa4prI"/><Cite Key="BaMa4prII"/>,
+* Many groups from the GAP character table library <Cite Key="CaMaBrauerTree"/>.

--- a/lib/HeLP.gd
+++ b/lib/HeLP.gd
@@ -54,7 +54,6 @@
 #! @Returns <K>true</K> if (ZC) can be solved using the given data, <K>false</K> otherwise
 DeclareGlobalFunction( "HeLP_ZC" );
 #! @InsertChunk ZCExample
-#! @EndSection
 
 
 #! @Section Prime Graph Question
@@ -86,7 +85,6 @@ DeclareGlobalFunction( "HeLP_ZC" );
 #! @Returns <K>true</K> if (PQ) can be solved using the given data, <K>false</K> otherwise
 DeclareGlobalFunction( "HeLP_PQ" );
 #! @InsertChunk PQExample
-#! @EndSection
 
 
 ####################################

--- a/lib/HeLP.gd
+++ b/lib/HeLP.gd
@@ -456,9 +456,9 @@ DeclareGlobalFunction( "HeLP_WagnerTest" );
 
 #! @Description
 #!  For a list of possible partial augmentations, this function calculates representatives of each orbit of the action of the automorphism group of $G$
-#!  on them.  The first two mandatory arguments are an ordinary character table <A>C</A> (with an underlying group or ) and the order <A>k</A> for which the partial augmentations
-#!  should be filtered with respect to the action of the automorphism group of $G$.  If as third argument a lisrt of partial augmentations is given,
-#!  then these will be used, otherwise the partial augmentations that are stored in <K>HeLP_sol[k]</K> are used.
+#!  on them.  The first two mandatory arguments are an ordinary character table <A>C</A> (with an underlying group or Identifier) and the order <A>k</A> for which the partial augmentations
+#!  should be filtered with respect to the action of the automorphism group of $G$.  If as third argument a list of partial augmentations is given,
+#!  then this will be used, otherwise the partial augmentations that are stored in <K>HeLP_sol[k]</K> are used.
 #! @Arguments C, k [, list_paraug]
 #! @Returns List of admissible partial augmentations
 DeclareGlobalFunction( "HeLP_AutomorphismOrbits" );
@@ -471,7 +471,7 @@ DeclareGlobalFunction( "HeLP_AutomorphismOrbits" );
 #! @Description
 #!  This function prints the possible solutions in a pretty way.  If a positive integer <A>k</A> as argument is given, then it prints the
 #!  admissible partial augmentations of units of order <A>k</A>, if they are already calculated.  If no argument is given, the 
-#!  function prints information on all orders for which there are already informations.
+#!  function prints information on all orders for which there is already information.
 #! @Arguments [k]
 #! @Returns nothing
 DeclareGlobalFunction( "HeLP_PrintSolution" );

--- a/tst/yes_normaliz.tst
+++ b/tst/yes_normaliz.tst
@@ -35,14 +35,14 @@ gap> HeLP_ZC(G);
 gap> Size(HeLP_sol[4]);
  10
 
+gap> SetInfoLevel(HeLP_Info, 0);
 gap> C1 := CharacterTable(PSL(2,7));;
 gap> HeLP_PQ(C1);
- #I  The Brauer tables for the following primes are not available: [ 2, 3, 7 ]. 
- #I  (PQ) can't be solved, using the given data, for the orders: [ 6 ].
  false
 gap> C2 := CharacterTable("L2(7)");;  
 gap> HeLP_PQ(C2);                  
  true
+gap> SetInfoLevel(HeLP_Info, 1);
 
 gap> C := CharacterTable("L2(49).2_1");;
 gap> HeLP_WithGivenOrder(Irr(C), 7);;


### PR DESCRIPTION
I imported the 3.5 release into git, and carefully restored the few changes that were made in git in the meantime and that were missing in 3.5.

I recommend to merge this, then re-release it (with a fresh date). Since the tarball was never put on the website, nor the PackageInfo.g, the "bad" version 3.5 was never picked up, so it's safe to reuse the version (but I'd update the release date anyway).

The release then should be made properly with [ReleaseTools](https://github.com/gap-system/ReleaseTools) this time around.

Resolves  #6