### PR TITLE
Load NormalizInterface via its full name

### DIFF
--- a/lib/HeLP.gi
+++ b/lib/HeLP.gi
@@ -1201,10 +1201,10 @@ elif Size(arg) = 1 and arg[1] in ["4ti2", "normaliz"] then
   elif arg[1] = "normaliz" then
     BindGlobal("HeLP_settings", ["normaliz", h2, h3, h4]);
     Info( HeLP_Info, 1, "'normaliz' will be used from now on.");
-    if LoadPackage("normaliz") = fail then
+    if LoadPackage("NormalizInterface") = fail then
       Info( HeLP_Info, 1, "Though note I could not load the NormalizInterface package .\n");
     fi;
-#  elif arg[1] = "normaliz" and LoadPackage("normaliz") = fail then
+#  elif arg[1] = "normaliz" and LoadPackage("NormalizInterface") = fail then
 #    BindGlobal("HeLP_settings", [h1, h2, h3, h4]);
 #    Info( HeLP_Info, 1, "The executable 'BNmzCone' (from normaliz) was not found.\nPlease install normaliz. See the manual of the package NormalizInterface.\nThe calculations will be performed as before.");
   fi;

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -4,7 +4,7 @@ LoadPackage( pkgname );
 pkgdir := DirectoriesPackageLibrary( pkgname, "tst" );
 
 testresult := true;
-if LoadPackage("normaliz") <> fail then
+if LoadPackage("NormalizInterface") <> fail then
   Print("normaliz found\n");
   fn := Filename( pkgdir, "yes_normaliz.tst" );
   Print("#I  Testing ", fn, "\n");
@@ -22,7 +22,7 @@ if IO_FindExecutable( "zsolve" ) <> fail then
   fi;
 fi;
 
-if IO_FindExecutable( "zsolve" ) = fail and LoadPackage("normaliz") = fail then
+if IO_FindExecutable( "zsolve" ) = fail and LoadPackage("NormalizInterface") = fail then
   fn := Filename( pkgdir, "no_solver.tst" );
   Print("No solver found\n");
   if not Test( fn, rec(compareFunction := "uptowhitespace") ) then


### PR DESCRIPTION
Allowing abbreviated names is only intended for user convenience, but
should not be used in regular code, as it can fail or lead to otherwise
unexpected results. E.g. on my system there is another package whose
name starts with 'normaliz', causing LoadPackage("normaliz") to fail.